### PR TITLE
Added PyTorch to SafeTensors conversion function

### DIFF
--- a/examples/convert_to_safetensor.py
+++ b/examples/convert_to_safetensor.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+import re
+from pathlib import Path
+import torch
+from safetensors.torch import save_file
+
+
+def get_latest_checkpoint(folder: Path) -> Path | None:
+    """
+    Return the latest .pt checkpoint in the given folder based on the
+    highest numeric suffix before the '.pt' extension.
+    Example: 'model_123.pt' -> step 123.
+    """
+    if not folder.is_dir():
+        return None
+
+    pt_files = list(folder.glob("*.pt"))
+    if not pt_files:
+        return None
+
+    def extract_step(file_path: Path) -> int:
+        match = re.search(r"_(\d+)(?=\.pt$)", file_path.name)
+        return int(match.group(1)) if match else -1
+
+    return max(pt_files, key=extract_step)
+
+
+def convert_to_safetensors(pt_path: Path, output_path: Path) -> None:
+    """
+    Convert a PyTorch '.pt' checkpoint file to safetensors format.
+
+    Loads the checkpoint to CPU, extracts the state dict, moves all tensors to CPU,
+    and saves them in safetensors format to 'output_path'.
+    """
+    checkpoint = torch.load(pt_path, map_location="cpu")
+
+    if isinstance(checkpoint, dict):
+        state_dict = (
+            checkpoint.get("model_state_dict")
+            or checkpoint.get("state_dict")
+            or checkpoint
+        )
+    else:
+        raise ValueError(f"Unexpected checkpoint format: {type(checkpoint)}")
+
+    tensors = {k: v.cpu() for k, v in state_dict.items() if isinstance(v, torch.Tensor)}
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    save_file(tensors, output_path)
+
+
+def process_model(name: str, input_dir: str, output_path: str) -> None:
+    """
+    Find the latest checkpoint in 'input_dir' and convert it to safetensors format.
+    """
+    latest_ckpt = get_latest_checkpoint(Path(input_dir))
+    if latest_ckpt:
+        print(f"Converting {name} checkpoint: {latest_ckpt}")
+        convert_to_safetensors(latest_ckpt, Path(output_path))
+        print(f"Saved safetensors to: {output_path}")
+    else:
+        print(f"No checkpoint found for {name}")
+
+
+if __name__ == "__main__":
+    process_model("nanospeech", "model/nanospeech", "models/model.safetensors")
+    process_model("duration", "model/duration", "models/duration.safetensors")

--- a/tutorial/README.md
+++ b/tutorial/README.md
@@ -403,7 +403,28 @@ Once we've finished training the duration prediction model, we're ready to gener
 
 To start generating speech, we'll take the three key pieces that we've produced and upload them to a Hugging Face model repository.
 
-Nanospeech uses the [safetensors](https://huggingface.co/docs/safetensors/convert-weights) format for model storage, which is widely used and portable between machine learning frameworks like PyTorch and MLX.
+Nanospeech uses the **safetensors** format for model storage, which is widely used and portable between machine learning frameworks like PyTorch and MLX.
+
+To convert a PyTorch checkpoint (.pt) to .safetensors, you can use the following helper function:
+
+```commandline
+def convert_to_safetensors(pt_path: Path, output_path: Path) -> None:
+    checkpoint = torch.load(pt_path, map_location="cpu")
+
+    if isinstance(checkpoint, dict):
+        state_dict = (
+            checkpoint.get("model_state_dict")
+            or checkpoint.get("state_dict")
+            or checkpoint
+        )
+    else:
+        raise ValueError(f"Unexpected checkpoint format: {type(checkpoint)}")
+
+    tensors = {k: v.cpu() for k, v in state_dict.items() if isinstance(v, torch.Tensor)}
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    save_file(tensors, output_path)
+```
+
 
 After converting the model weights to the safetensors format, we'll upload these files:
 


### PR DESCRIPTION
## Summary
Add a simple script to locate the latest PyTorch .pt checkpoints, convert them to safetensors format, and save them. Update README with the same.

## Changes
- Added `examples/convert_to_safetensor.py`:
  - Convert latest .pt checkpoints to safetensor

- Updated `README.md`:
  - Added instructions for converting `.pt` to `.safetensors`.
  
## Example usage
```sh
python convert_checkpoints.py